### PR TITLE
BUGFIX: Removed spurious prinln from CommandSwerveDriveTrain

### DIFF
--- a/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/CommandSwerveDrivetrain.java
@@ -428,7 +428,6 @@ public class CommandSwerveDrivetrain extends TunerSwerveDrivetrain implements Su
     // Rather than hardcoding to rawFiducials[0], iterate any instances it may have.
     // (e.g., if a given LimeLight can see multiple AprilTags)
     private static double bestAmbiguity(LimelightHelpers.PoseEstimate p) {
-        System.out.println(p);
         return Arrays.stream(p.rawFiducials)
             .mapToDouble(f -> f.ambiguity)
             .min()


### PR DESCRIPTION
- Bot code had a println statement that was filling up the logs.
- Try to use SmartDashboard rather than printing to the console where possible!