### PR TITLE
Optimize driver control inputs

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -66,11 +66,8 @@ public class RobotContainer {
 
     // Control
     private final CommandXboxController driver = new CommandXboxController(Constants.Controller.DRIVER_PORT);
+    private final XboxController driver_hid = driver.getHID();
     private final CommandXboxController operator = new CommandXboxController(Constants.Controller.OPERATOR_PORT);
-    private final DoubleSupplier translationSup = () -> driver.getRawAxis(XboxController.Axis.kLeftY.value); // forward/backward on left stick
-    private final DoubleSupplier strafeSup = () -> driver.getRawAxis(XboxController.Axis.kLeftX.value); // right/left on left stick
-    private final DoubleSupplier rotationSup = () -> driver.getRawAxis(XboxController.Axis.kRightX.value); // right/left on right stick 
-
 
     public static final Kicker kicker = new Kicker();
     public static final Hood hood = new Hood();
@@ -104,7 +101,12 @@ public class RobotContainer {
         // Note that X is defined as forward according to WPILib convention,
         // and Y is defined as to the left according to WPILib convention.
         drivetrain.setDefaultCommand(
-            new TeleopSwerve(drivetrain, translationSup, strafeSup, rotationSup)
+            new TeleopSwerve(
+                drivetrain,
+                () -> driver_hid.getLeftY(),
+                () -> driver_hid.getLeftX(),
+                () -> driver_hid.getRightX()
+            )
         );
 
         // always try to go to default


### PR DESCRIPTION
As described by https://www.chiefdelphi.com/t/command-scheduler-loop-overrun-causes-and-remedies/457999/4 this was essentially creating an new double instance on each instance of the main loop. This was noticed by a nearly 30ms loop timing on `buttons.run()`