### PR TITLE
spotlessCheck on all builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,6 +127,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 
+project.compileJava.dependsOn(spotlessCheck)
 spotless {
     java {
         target fileTree('.') {

--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ repositories {
     maven { url 'https://jitpack.io' }
 }
 
-project.compileJava.dependsOn(spotlessCheck)
+project.compileJava.dependsOn(spotlessApply)
 spotless {
     java {
         target fileTree('.') {


### PR DESCRIPTION
We should have a discussion if this should perform a spotlessApply instead, or instead error out so the user runs it instead (as it is currently configured). At this point, I don't think it makes a difference since we pretty much blindly accept it now. Also, this isn't doing that many code formatting changes either since that is commented out.